### PR TITLE
send http server metrics to customizable bucket

### DIFF
--- a/akka-statsd-spray-server/src/test/scala/StatsDirectivesSpec.scala
+++ b/akka-statsd-spray-server/src/test/scala/StatsDirectivesSpec.scala
@@ -92,6 +92,21 @@ class StatsDirectivesSpec
         received.exists(_.isInstanceOf[Timing]) must equal (true)
       }
     }
+    it("Changes teh bucket if specified") {
+      val route = countAndTimeInBucket("init.bucket") {
+        getFooBar
+      }
+
+      Get("/foo/bar") ~>
+        route ~>
+        check {
+          val received = receiveN(2)
+          val expectedBucket = scala.collection.Set("init.bucket.get.foo.bar")
+          received.map { case m: Metric[_] => m.bucket.render }.toSet must equal(expectedBucket)
+          received.exists(_.isInstanceOf[Increment]) must equal (true)
+          received.exists(_.isInstanceOf[Timing]) must equal (true)
+        }
+    }
   }
 
   describe("Stats directives") {


### PR DESCRIPTION
It is handy and more flexible to be able to set a different initial bucket. This initial bucket can contain additional information like user name or some other categorization information.