### PR TITLE
Make Daan a Happy Camper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,55 @@
 
 A dead simple [statsd] client written in Scala as group of actors using the [akka] framework.
 
+## Installation
+
+Releases and snapshots are hosted on The New Motion public repository. To add dependency to your project use following snippet:
+
+```scala
+libraryDependencies += "com.newmotion" %% "akka-statsd-core" % "2.0.0-SNAPSHOT"
+```
+
+For stats collection over HTTP requests served by akka-http server add:
+```
+libraryDependencies += "com.newmotion" %% "akka-statsd-http-server" % "2.0.0-SNAPSHOT"
+```
+
+## Configuration
+
+By default `Stats.props()` uses `Config` which is constructed by resolving Typesafe Config with call to `ConfigFactory.load()`.
+You may use `akkas.statsd.Config`, constructed manually or from provided Typesafe Config instance too. 
+Here are the default settings, with the exception of hostname, which is a required setting:
+
+```
+akka.statsd {
+        # hostname = "required"
+        port = 8125
+        namespace = ""
+        # common packet sizes:
+        # gigabit ethernet:     8932
+        # fast ethernet:        1432
+        # commodity internet:    512
+        packet-size = 1432
+        transmit-interval = 100 ms
+
+        transformations = [
+          {
+            pattern = "foo"
+            into = "bar"
+          }
+        ]
+    }
+}
+```
+
+## Simplest Example
+
+```scala
+class SimpleExample extends App {
+  lazy val stats = context.actorOf(Stats.props())
+  stats ! Increment(Bucket("my.thingie.that.counts.app.starts"))
+}
+
 ## Naming conventions
 
 The New Motion recommends using the following naming conventions:
@@ -16,7 +65,7 @@ the application a one or two word description of the application separated by da
 
 Think about the hierarchy you want to use inside your application, this will be of great influence on the representation side
 
-## Examples
+## More Examples
 
 ```scala
 class Counter(val counterName: String) extends Actor {
@@ -92,22 +141,6 @@ Stats.withTimer(Bucket("code.execution.time")) {
 }
 ```
 
-
-
-## Installation
-
-Releases and snapshots are hosted on The New Motion public repository. To add dependency to your project use following snippet:
-
-```scala
-libraryDependencies += "com.newmotion" %% "akka-statsd-core" % "2.0.0-SNAPSHOT"
-```
-
-For stats collection over HTTP requests served by akka-http server add:
-```
-libraryDependencies += "com.newmotion" %% "akka-statsd-http-server" % "2.0.0-SNAPSHOT"
-```
-
-
 ## Explanation
 
 This implementation is intended to be of high performance, thus it
@@ -154,34 +187,6 @@ Please note that:
 - transformations are matched from top to bottom
 - every transformation that matches the path will be applied
 
-
-## Configuration
-
-By default `Stats.props()` uses `Config` which is constructed by resolving Typesafe Config with call to `ConfigFactory.load()`.
-You may use `akkas.statsd.Config`, constructed manually or from provided Typesafe Config instance too. 
-Here are the default settings, with the exception of hostname, which is a required setting:
-
-```
-akka.statsd {
-        # hostname = "required"
-        port = 8125
-        namespace = ""
-        # common packet sizes:
-        # gigabit ethernet:     8932
-        # fast ethernet:        1432
-        # commodity internet:    512
-        packet-size = 1432
-        transmit-interval = 100 ms
-
-        transformations = [
-          {
-            pattern = "foo"
-            into = "bar"
-          }
-        ]
-    }
-}
-```
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -192,14 +192,14 @@ Any `UUID` in the bucket path substituted with token `[id]`. In addition to this
 
 In order to do so, the client configuration should contain `akka.statsd.transformations` section of the following format:
 
-"""
+```
 akka.statsd.transformations = [
   {
     pattern = "/foo/[a-z0-9]+/bar",
     into    = "/foo/[segment]/bar"
   }
 ]
-"""
+```
 
 This reads as: if the part of the bucket matches the regular expression in `pattern`, replace it with the one described in `into` (which is *not* a regular expression).
 


### PR DESCRIPTION
...user of this library
see conversation in slack
```
daan [11:04 AM] 
So guys! For my work at KLM I was in need of a way to send metrics to a StatsD (compatible) daemon, from Spark (Scala) code

[11:04]  
And I remembered that NewMotion had an open source lib for that

[11:05]  
I found it here: https://github.com/NewMotion/akka-statsd
github.com
GitHub - NewMotion/akka-statsd: Statsd client using an Akka actor
akka-statsd - Statsd client using an Akka actor

[11:05]  
I gotta be honest: the readme is _not super clear_

[11:06]  
Instead of first showing a simple example on how to use it in it's simplest way, I immediately get bombarded with best practices and contrived examples that don't clearly tell me what the API of the library is

[11:07]  
What I would have expected:
- an example of the minimum basic configuration the lib needs, and where to put it
- a code example that shows how to use the lib in it's simplest form: create an actor system, create an instance of the statsd actor, send some stuff to the actor to make it send stuff to StatsD

[11:09]  
What I get:

> The namespace is set by adding `[environment].[application]` in the application.conf
How exactly? Where in the config? What key?

> environment can be test, sandbox, prod and even unittest the application a one or two word description of the application separated by dashes
Does it need to be one of these environments? Does the library check for that in some way?

> [code example]
Why do I need to develop my own actor? Isn't this lib as simple as: instantiate existing statsd actor and send messages to it? I want an example of that :slightly_smiling_face: (edited)

[11:11]  
Anyways, some clarity would be welcome :slightly_smiling_face:
```