### PR TITLE
Add config option to empty whole queue on flush

### DIFF
--- a/akka-statsd-core/src/main/resources/reference.conf
+++ b/akka-statsd-core/src/main/resources/reference.conf
@@ -17,6 +17,8 @@ akka.statsd {
   transmit-interval = 100 ms
 
   enable-multi-metric = true
+  
+  empty-queue-on-flush = false
 
   # must be of form
   # {

--- a/akka-statsd-core/src/main/scala/Config.scala
+++ b/akka-statsd-core/src/main/scala/Config.scala
@@ -13,6 +13,7 @@ case class Config(
   packetSize: Int,
   transmitInterval: FiniteDuration,
   enableMultiMetric: Boolean,
+  emptyQueueOnFlush: Boolean,
   transformations: Seq[Transformation]
 )
 
@@ -33,6 +34,7 @@ object Config {
       packetSize = cfg.as[Int]("packet-size"),
       transmitInterval = cfg.as[FiniteDuration]("transmit-interval"),
       enableMultiMetric = cfg.as[Boolean]("enable-multi-metric"),
+      emptyQueueOnFlush = cfg.as[Boolean]("empty-queue-on-flush"),
       transformations =
         cfg.as[Seq[FicusConfig]]("transformations").map(transformation)
     )

--- a/akka-statsd-core/src/main/scala/transport/MultiMetricQueue.scala
+++ b/akka-statsd-core/src/main/scala/transport/MultiMetricQueue.scala
@@ -81,6 +81,12 @@ private[statsd] class MultiMetricQueue(val packetSize: Int)(implicit system: Act
     }
   }
 
+  /**
+    * Creates as many payloads as necessary to empty the queue.
+    * This ensures we flush the whole queue at every flush command and prevents memory growing out of control.
+    */
+  def flushQueue(): Stream[String] = Stream.continually(payload()).takeWhile(_.nonEmpty).flatten
+
   private object DroppedMessageWarning extends ((Int, String) => Unit) {
     def apply(proposedAddition: Int, message: String) {
       if (!logger.isWarningEnabled)

--- a/akka-statsd-core/src/main/scala/transport/ScheduledDispatcher.scala
+++ b/akka-statsd-core/src/main/scala/transport/ScheduledDispatcher.scala
@@ -44,7 +44,8 @@ private[statsd] class ScheduledDispatcher(
         connection ! msg
       }
     case Transmit =>
-      mmq.payload().foreach(connection ! _)
+      if (config.emptyQueueOnFlush) mmq.flushQueue().foreach(connection ! _)
+      else mmq.payload().foreach(connection ! _)
   }
 
   override def postStop() {

--- a/akka-statsd-core/src/test/scala/transport/MultiMetricQueueFunSpec.scala
+++ b/akka-statsd-core/src/test/scala/transport/MultiMetricQueueFunSpec.scala
@@ -73,5 +73,16 @@ class MultiMetricQueueFunSpec
             |2""".stripMargin))
       }
     }
+
+    describe("when the queue is larger than the packet size") {
+      it("returns as many payloads as necessary to empty the queue when calling flushQueue") {
+        val subject = MultiMetricQueue(4).enqueue("12").enqueue("34").enqueue("56").enqueue("7")
+        assert(subject.flushQueue() ==
+          Stream("""12
+                 |34""".stripMargin,
+                """56
+                  |7""".stripMargin))
+      }
+    }
   }
 }

--- a/akka-statsd-core/src/test/scala/transport/ScheduledDispatcherSpec.scala
+++ b/akka-statsd-core/src/test/scala/transport/ScheduledDispatcherSpec.scala
@@ -79,7 +79,7 @@ class ScheduledDispatcherSpec
     }
   }
 
-  private class Environment(transmitInterval: Long, emptyQueueOnFlush: Boolean = false) {
+  private class Environment(transmitInterval: Long) {
     def config = Config(
       ConfigFactory
         .load("ScheduledDispatcherSpec.conf")

--- a/akka-statsd-core/src/test/scala/transport/ScheduledDispatcherSpec.scala
+++ b/akka-statsd-core/src/test/scala/transport/ScheduledDispatcherSpec.scala
@@ -55,6 +55,14 @@ class ScheduledDispatcherSpec
               |three
               |four""".stripMargin)
         }
+        "combine all the messages and send all the necessary payloads if emptyQueueOnFlush is true" in new QueueFlushEnvironment(10, 250) {
+          val scheduled = system.actorOf(ScheduledDispatcher.props(config, forwardTo(testActor)))
+          Seq("one", "two", "three", "four").foreach(msg => scheduled ! msg)
+          receiveN(2, 300.millis) shouldBe Seq("""one
+                                                  |two""".stripMargin,
+                                               """three
+                                                  |four""".stripMargin)
+        }
       }
       "some messages are staggered after the transmitInterval" should {
         "receive one batch of messages and then another" in new Environment(50) {
@@ -71,7 +79,7 @@ class ScheduledDispatcherSpec
     }
   }
 
-  private class Environment(transmitInterval: Long) {
+  private class Environment(transmitInterval: Long, emptyQueueOnFlush: Boolean = false) {
     def config = Config(
       ConfigFactory
         .load("ScheduledDispatcherSpec.conf")
@@ -84,6 +92,14 @@ class ScheduledDispatcherSpec
     }
 
     def forwardTo(recipient: ActorRef) = Props(new Forwarder(recipient))
+  }
+
+  private class QueueFlushEnvironment(
+    packetSize: Int,
+    transmitInterval: Long
+  ) extends Environment(transmitInterval) {
+
+    override def config = super.config.copy(packetSize = packetSize, emptyQueueOnFlush = true)
   }
 
   private class ExceptionCaptureEnvironment(


### PR DESCRIPTION
Hi !
We're adding statsd instrumentation to our workflow engine (https://github.com/broadinstitute/cromwell) and we'd like to use your code :)

We would like to take advantage of the multi-metric batching, my only concern is that under very heavy load it would be possible for the queue to grow out of control (considering a transmit interval of 100ms it means only 10 flushes / second). We could lower the interval or increase the number of Stats actors to mitigate that risk but I would like to be sure that the queue can't grow indefinitely if the load is too high and would rather lose packets to the network.

I was wondering if you would consider accepting this PR that adds an option to empty the entire queue on each flush.

I'm of course open to any feedback, requests you have (or if you think it's a bad idea don't hesitate to let me know either 😄 )

Thank you !