### PR TITLE
Second attempt to fix bug where StatsDirective would create a new act…

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,13 @@ Forked from github repo at [cfeduke/akka-actor-statsd](https://github.com/cfeduk
 
 ## Changelog
 
+### 3.0.2
+
+Previous bug was not fixed properly, because 
+* StatsDirectives loaded the config every time it sent a stat
+* Two Configs that appear equal were not, due to one Regex not being equal to another even when 
+created from the same string
+
 ### 3.0.1
 
 Fixed a bug where akka-statsd-http-server StatsDirective would create a new actor for every stat it sends

--- a/akka-statsd-core/src/main/scala/Bucket.scala
+++ b/akka-statsd-core/src/main/scala/Bucket.scala
@@ -2,8 +2,8 @@ package akka.statsd
 
 import scala.util.matching.Regex
 
-
-case class Transformation(regex: Regex, into: String) {
+case class Transformation(regexS: String, into: String) {
+  val regex = new Regex(regexS)
   def apply(s: String): String = regex.replaceAllIn(s, into)
 }
 
@@ -32,11 +32,11 @@ object Bucket {
 
   private val delimiter = "."
   private val defaults = {
-    val reservedSymbols = Transformation("""[:|@\\]""".r, "_")
-    val partDelimiters = Transformation("""[/]""".r, delimiter)
+    val reservedSymbols = Transformation("""[:|@\\]""", "_")
+    val partDelimiters = Transformation("""[/]""", delimiter)
     val uuid = {
       val hex = """[a-fA-F\d]"""
-      Transformation(s"""$hex{8}-$hex{4}-$hex{4}-$hex{4}-$hex{12}""".r, "[id]")
+      Transformation(s"""$hex{8}-$hex{4}-$hex{4}-$hex{4}-$hex{12}""", "[id]")
     }
 
     Seq(reservedSymbols, partDelimiters, uuid)

--- a/akka-statsd-core/src/main/scala/Config.scala
+++ b/akka-statsd-core/src/main/scala/Config.scala
@@ -3,7 +3,6 @@ package akka.statsd
 import java.net.InetSocketAddress
 import com.typesafe.config.{Config => TsConfig, _}
 import scala.concurrent.duration._
-import scala.util.matching.Regex
 import scala.concurrent.duration.MILLISECONDS
 import scala.collection.JavaConverters._
 
@@ -24,7 +23,7 @@ object Config {
     val cfg = underlying.getConfig(path)
 
     def transformation(c: TsConfig) =
-      Transformation(new Regex(c.getString("pattern")), c.getString("into"))
+      Transformation(c.getString("pattern"), c.getString("into"))
 
     Config(
       new InetSocketAddress(cfg.getString("hostname"), cfg.getInt("port")),

--- a/akka-statsd-core/src/test/scala/BucketSpec.scala
+++ b/akka-statsd-core/src/test/scala/BucketSpec.scala
@@ -34,14 +34,14 @@ class BucketSpec
     }
 
     it("favors provided transformations over default ones") {
-      val ts = Seq(Transformation(".+".r, "anything"))
+      val ts = Seq(Transformation(".+", "anything"))
 
       Bucket(java.util.UUID.randomUUID.toString, ts) must equal(
         Bucket("anything", ts))
     }
 
     it("transforms over several path parts") {
-      val ts = Seq(Transformation("""[a-z]+\.\d+""".r, "alphanum"))
+      val ts = Seq(Transformation("""[a-z]+\.\d+""", "alphanum"))
 
       (Bucket("abc", ts) / "999").render must equal(
         Bucket("alphanum", ts).render)

--- a/akka-statsd-core/src/test/scala/ConfigSpec.scala
+++ b/akka-statsd-core/src/test/scala/ConfigSpec.scala
@@ -26,5 +26,24 @@ class ConfigSpec
       config.address.getPort should be(9999)
       config.namespace should be("mango")
     }
+
+    it("is equal when loaded with the same parameters") {
+      def load() =
+        Config(ConfigFactory.parseString(
+          """
+        {
+          akka.statsd.hostname = localhost
+          akka.statsd.transformations = [
+            {
+              pattern = "/foo/[a-zA-Z0-9\\-]+/bar"
+              into = "foo.[segment].bar"
+            }
+          ]
+        }
+      """
+        ).withFallback(ConfigFactory.load))
+
+      load() should equal(load())
+    }
   }
 }

--- a/akka-statsd-http-server/src/main/scala/StatsDirectives.scala
+++ b/akka-statsd-http-server/src/main/scala/StatsDirectives.scala
@@ -16,7 +16,9 @@ trait StatsDirectives extends AroundDirectives with BasicDirectives {
   /**
     * Override this in the calling class when you want to specify your own configuration
     */
-  def statsConfig: StatsConfig = StatsConfig()
+  def loadStatsConfig(): StatsConfig = StatsConfig()
+
+  private lazy val statsConfig = loadStatsConfig()
 
   protected val extractStats: Directive1[ActorRef] =
     extractActorSystem.map {

--- a/akka-statsd-http-server/src/test/scala/StatsDirectivesSpec.scala
+++ b/akka-statsd-http-server/src/test/scala/StatsDirectivesSpec.scala
@@ -25,7 +25,7 @@ class StatsDirectivesSpec
 
   def actorRefFactory = system
 
-  override val statsConfig =
+  override def loadStatsConfig() =
     Config(ConfigFactory.parseString(
       """
         {

--- a/akka-statsd-http-server/src/test/scala/StatsExtensionSpec.scala
+++ b/akka-statsd-http-server/src/test/scala/StatsExtensionSpec.scala
@@ -14,7 +14,7 @@ class StatsExtensionSpec
   with FunSpecLike
   with MustMatchers {
 
-  val statsConfig =
+  def loadStatsConfig =
     Config(ConfigFactory.parseString(
       """
         {
@@ -31,15 +31,15 @@ class StatsExtensionSpec
 
   describe("stats extension") {
     it("gets the same actor for the same config") {
-      val actor1 = StatsExtension(system).statsActor(statsConfig)
-      val actor2 = StatsExtension(system).statsActor(statsConfig)
+      val actor1 = StatsExtension(system).statsActor(loadStatsConfig)
+      val actor2 = StatsExtension(system).statsActor(loadStatsConfig)
 
       actor1 must equal(actor2)
     }
 
     it("gets a different actor for a different config") {
-      val actor1 = StatsExtension(system).statsActor(statsConfig)
-      val actor2 = StatsExtension(system).statsActor(statsConfig.copy(namespace = "monkeys"))
+      val actor1 = StatsExtension(system).statsActor(loadStatsConfig)
+      val actor2 = StatsExtension(system).statsActor(loadStatsConfig.copy(namespace = "monkeys"))
 
       actor1 must not equal(actor2)
     }


### PR DESCRIPTION
Previous bug was not fixed properly, because:

* StatsDirectives loaded the config every time it sent a stat
* Two Configs that appear equal were not, due to one Regex not being equal to another even when 
created from the same string