### PR TITLE
Improved, more functional client

### DIFF
--- a/akka-statsd-core/src/main/scala/statsExtension.scala
+++ b/akka-statsd-core/src/main/scala/statsExtension.scala
@@ -1,8 +1,7 @@
-package akka.statsd.http.server
+package akka.statsd
 
 import akka.actor.{ActorRef, ExtendedActorSystem, Extension, ExtensionId}
-import akka.statsd.Stats
-import akka.statsd.{Config => StatsConfig, _}
+import akka.statsd.{Config => StatsConfig}
 import java.util.concurrent.ConcurrentHashMap
 import scala.compat.java8.FunctionConverters._
 

--- a/akka-statsd-http-client/src/test/scala/StatsClientSpec.scala
+++ b/akka-statsd-http-client/src/test/scala/StatsClientSpec.scala
@@ -3,26 +3,22 @@ package akka.statsd.http.client
 import scala.concurrent.duration._
 import akka.actor.{ActorRef, ActorSystem}
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.statsd.http.client.StatsClient.ReqRes
 import akka.statsd.{Config, Increment, Timing}
 import akka.testkit.{TestKitBase, TestProbe}
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{AsyncFunSpecLike, MustMatchers}
+import org.scalatest.{Assertion, AsyncFunSpecLike, MustMatchers}
 import scala.concurrent.Future
 
 class StatsClientSpec extends {
   override implicit val system: ActorSystem = ActorSystem()
 } with TestKitBase with AsyncFunSpecLike with MustMatchers {
 
-  class TestClient(
-    probe: TestProbe,
-    singleRequest: HttpRequest => Future[HttpResponse]
-  ) extends StatsClient(singleRequest) {
-
-    override val statsConfig =
-      Config(
-        ConfigFactory
-          .parseString(
-            """
+  implicit val statsConfig =
+    Config(
+      ConfigFactory
+        .parseString(
+          """
         {
           akka.statsd.hostname = localhost
           akka.statsd.transformations = [
@@ -33,43 +29,82 @@ class StatsClientSpec extends {
           ]
         }
       """
-          )
-          .withFallback(ConfigFactory.load)
-      )
+        )
+        .withFallback(ConfigFactory.load)
+    )
 
-    override def createStatsActor(): ActorRef = probe.ref
+  def withClient(test: (TestProbe, StatsClient) => Future[Assertion]): Future[Assertion] = {
+    val probe = TestProbe()
+
+    val client = new StatsClient {
+      override protected def statsActor(system: ActorSystem, statsConfig: Config): ActorRef = probe.ref
+    }
+
+    test(probe, client)
   }
 
   describe("Stats Client") {
     it("tracks request counts") {
-      val probe = TestProbe()
-      val client = new TestClient(probe, _ => Future.successful(HttpResponse())) with CountRequests
-      client.singleRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
-        probe.expectMsgPF(1.second) {
-          case m: Increment =>
-            m.bucket.render must equal("http.client.request.get.http.www-monkeys-com.foo.bar")
+      withClient { (probe, client) =>
+        val makeRequest = client.countRequests(_ => Future.successful(HttpResponse()))
+
+        makeRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
+          probe.expectMsgPF(1.second) {
+            case m: Increment =>
+              m.bucket.render must equal("http.client.request.get.http.www-monkeys-com.foo.bar")
+          }
         }
       }
     }
 
     it("tracks response counts") {
-      val probe = TestProbe()
-      val client = new TestClient(probe, _ => Future.successful(HttpResponse())) with CountResponses
-      client.singleRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
-        probe.expectMsgPF(1.second) {
-          case m: Increment =>
-            m.bucket.render must equal("http.client.response.get.2xx.http.www-monkeys-com.foo.bar")
+      withClient { (probe, client) =>
+        val makeRequest = client.countResponses(_ => Future.successful(HttpResponse()))
+
+        makeRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
+          probe.expectMsgPF(1.second) {
+            case m: Increment =>
+              m.bucket.render must equal("http.client.response.get.2xx.http.www-monkeys-com.foo.bar")
+          }
         }
       }
     }
 
     it("tracks response times") {
-      val probe = TestProbe()
-      val client = new TestClient(probe, _ => Future.successful(HttpResponse())) with TimeResponses
-      client.singleRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
-        probe.expectMsgPF(1.second) {
-          case m: Timing =>
-            m.bucket.render must equal("http.client.response.get.2xx.http.www-monkeys-com.foo.bar")
+      withClient { (probe, client) =>
+        val makeRequest = client.timeResponses(_ => Future.successful(HttpResponse()))
+        makeRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
+          probe.expectMsgPF(1.second) {
+            case m: Timing =>
+              m.bucket.render must equal("http.client.response.get.2xx.http.www-monkeys-com.foo.bar")
+          }
+        }
+      }
+    }
+
+    it("can compose different stats") {
+      withClient { (probe, client) =>
+
+        import client._
+
+        val makeRequest =
+          Function.chain(
+            Seq(
+              countResponses(_: ReqRes),
+              countRequests(_: ReqRes)
+            )
+          )(_ => Future.successful(HttpResponse()))
+
+        makeRequest(HttpRequest(uri = "http://www.monkeys.com/foo/bar")).map { _ =>
+          probe.expectMsgPF(1.second) {
+            case m: Increment =>
+              m.bucket.render must equal("http.client.request.get.http.www-monkeys-com.foo.bar")
+          }
+
+          probe.expectMsgPF(1.second) {
+            case m: Increment =>
+              m.bucket.render must equal("http.client.response.get.2xx.http.www-monkeys-com.foo.bar")
+          }
         }
       }
     }


### PR DESCRIPTION
This update gets rid of the idea of different traits for different measurements in the StatsClient and instead bases everything around a function definition of `HttpRequest => Future[HttpResponse]`