### PR TITLE
Flag to disable transformation of UUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ akka.statsd {
         packet-size = 1432
         transmit-interval = 100 ms
 
+        transform-uuid = true
+
         transformations = [
           {
             pattern = "foo"
@@ -188,7 +190,9 @@ This can be turned off in the configuration by setting `enable-multi-metric = fa
 
 ## Bucket transformations
 
-Any `UUID` in the bucket path substituted with token `[id]`. In addition to this, clients can specify custom transformations to influence the way bucket names are augmented before being sent to StatsD server.
+If the `transform-uuid` option is enabled, any `UUID` in the bucket path substituted with token `[id]`. 
+
+In addition to this, clients can specify custom transformations to influence the way bucket names are augmented before being sent to StatsD server.
 
 In order to do so, the client configuration should contain `akka.statsd.transformations` section of the following format:
 
@@ -294,6 +298,10 @@ This will send 3 stats:
 Forked from github repo at [cfeduke/akka-actor-statsd](https://github.com/cfeduke/akka-actor-statsd)
 
 ## Changelog
+
+### 3.0.7
+
+Added the `transform-uuid` flag
 
 ### 3.0.2
 

--- a/akka-statsd-core/src/main/resources/reference.conf
+++ b/akka-statsd-core/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ akka.statsd {
   transmit-interval = 100 ms
 
   enable-multi-metric = true
-  
+
   empty-queue-on-flush = false
 
   # must be of form
@@ -27,4 +27,5 @@ akka.statsd {
   # }
   transformations = []
 
+  transform-uuid = true
 }

--- a/akka-statsd-core/src/main/scala/Config.scala
+++ b/akka-statsd-core/src/main/scala/Config.scala
@@ -13,7 +13,8 @@ case class Config(
   transmitInterval: FiniteDuration,
   enableMultiMetric: Boolean,
   emptyQueueOnFlush: Boolean,
-  transformations: Seq[Transformation]
+  transformations: Seq[Transformation],
+  transformUuid: Boolean
 )
 
 object Config {
@@ -33,7 +34,8 @@ object Config {
         FiniteDuration(cfg.getDuration("transmit-interval", java.util.concurrent.TimeUnit.MILLISECONDS), MILLISECONDS),
       enableMultiMetric = cfg.getBoolean("enable-multi-metric"),
       emptyQueueOnFlush = cfg.getBoolean("empty-queue-on-flush"),
-      transformations = cfg.getConfigList("transformations").asScala.map(transformation)
+      transformations = cfg.getConfigList("transformations").asScala.map(transformation),
+      transformUuid = cfg.getBoolean("transform-uuid")
     )
   }
 }

--- a/akka-statsd-core/src/test/scala/BucketSpec.scala
+++ b/akka-statsd-core/src/test/scala/BucketSpec.scala
@@ -33,6 +33,11 @@ class BucketSpec
       Bucket(java.util.UUID.randomUUID.toString).render must equal(Bucket("[id]").render)
     }
 
+    it("does not substituted UUIDs for [id] when disabled") {
+      val uuid = java.util.UUID.randomUUID.toString
+      Bucket(uuid, transformUuid = false).render must equal(uuid)
+    }
+
     it("favors provided transformations over default ones") {
       val ts = Seq(Transformation(".+", "anything"))
 

--- a/akka-statsd-http-client/src/main/scala/StatsClient.scala
+++ b/akka-statsd-http-client/src/main/scala/StatsClient.scala
@@ -12,7 +12,7 @@ import StatsClient.ReqRes
 trait StatsClient {
 
   protected def bucket(bucketName: String)(implicit statsConfig: StatsConfig) =
-    Bucket(bucketName, statsConfig.transformations)
+    Bucket(bucketName, statsConfig.transformations, statsConfig.transformUuid)
 
   protected def uriToString(u: Uri): String = u.scheme + '.' + u.authority.toString.replace('.', '-') + u.path.toString
 

--- a/akka-statsd-http-server/src/main/scala/StatsDirectives.scala
+++ b/akka-statsd-http-server/src/main/scala/StatsDirectives.scala
@@ -27,7 +27,7 @@ trait StatsDirectives extends AroundDirectives with BasicDirectives {
 
   private def nowInNanos: Long = System.nanoTime
 
-  private def bucket(bucketName: String) = Bucket(bucketName, statsConfig.transformations)
+  private def bucket(bucketName: String) = Bucket(bucketName, statsConfig.transformations, statsConfig.transformUuid)
   private val defaultBucket = "http.server"
 
   private def requestBucket(m: HttpMethod, p: Uri.Path, initBucket: String): Bucket =


### PR DESCRIPTION
Added a flag in the config file called `transform-uuid` which is enabled by default in order that the behaviour is not changed.  However, when disabled, UUIDs will not be mapped to [id].  This should address issue https://github.com/NewMotion/akka-statsd/issues/10