### PR TITLE
Add option to use connected or unconnected udp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ A dead simple [statsd] client written in Scala as group of actors using the [akk
 Releases and snapshots are hosted on The New Motion public repository. To add dependency to your project use following snippet:
 
 ```scala
-libraryDependencies += "com.newmotion" %% "akka-statsd-core" % "3.0.1"
+libraryDependencies += "com.newmotion" %% "akka-statsd-core" % "3.1.0"
 ```
 
 For stats collection over HTTP requests served by akka-http server add:
 ```scala
-libraryDependencies += "com.newmotion" %% "akka-statsd-http-server" % "3.0.1"
+libraryDependencies += "com.newmotion" %% "akka-statsd-http-server" % "3.1.0"
 ```
 
 ## Configuration
@@ -42,6 +42,8 @@ akka.statsd {
             into = "bar"
           }
         ]
+        
+        connected-udp = true
     }
 }
 ```
@@ -298,6 +300,11 @@ This will send 3 stats:
 Forked from github repo at [cfeduke/akka-actor-statsd](https://github.com/cfeduke/akka-actor-statsd)
 
 ## Changelog
+
+### 3.1.0
+
+Added the connected-udp flag.  The default is true, and it behaves as before, setting up an Akka UDP Connection.  If
+set to false however, it will use Akka Unconnected UDP (see https://doc.akka.io/docs/akka/2.5.18/io-udp.html)
 
 ### 3.0.7
 

--- a/akka-statsd-core/src/main/resources/reference.conf
+++ b/akka-statsd-core/src/main/resources/reference.conf
@@ -28,4 +28,6 @@ akka.statsd {
   transformations = []
 
   transform-uuid = true
+
+  connected-udp = true
 }

--- a/akka-statsd-core/src/main/scala/Config.scala
+++ b/akka-statsd-core/src/main/scala/Config.scala
@@ -14,7 +14,8 @@ case class Config(
   enableMultiMetric: Boolean,
   emptyQueueOnFlush: Boolean,
   transformations: Seq[Transformation],
-  transformUuid: Boolean
+  transformUuid: Boolean,
+  connectedUdp: Boolean
 )
 
 object Config {
@@ -35,7 +36,8 @@ object Config {
       enableMultiMetric = cfg.getBoolean("enable-multi-metric"),
       emptyQueueOnFlush = cfg.getBoolean("empty-queue-on-flush"),
       transformations = cfg.getConfigList("transformations").asScala.map(transformation),
-      transformUuid = cfg.getBoolean("transform-uuid")
+      transformUuid = cfg.getBoolean("transform-uuid"),
+      connectedUdp = cfg.getBoolean("connected-udp")
     )
   }
 }

--- a/akka-statsd-core/src/main/scala/Stats.scala
+++ b/akka-statsd-core/src/main/scala/Stats.scala
@@ -31,7 +31,13 @@ object Stats {
   def bufferedConnection(cfg: Config): Props =
     ScheduledDispatcher.props(cfg, Connection.props(cfg.address))
 
-  def props(cfg: Config = Config(), conn: Config => Props = bufferedConnection): Props =
+  def bufferedUnconnected(cfg: Config): Props =
+    ScheduledDispatcher.props(cfg, UdpUnconnected.props(cfg.address))
+
+  def connectionFromConfig(cfg: Config): Props =
+    if (cfg.connectedUdp) bufferedConnection(cfg) else bufferedUnconnected(cfg)
+
+  def props(cfg: Config = Config(), conn: Config => Props = connectionFromConfig): Props =
     Props(new Stats(cfg, conn(cfg)))
 
   /**

--- a/akka-statsd-core/src/main/scala/transport/UdpUnconnected.scala
+++ b/akka-statsd-core/src/main/scala/transport/UdpUnconnected.scala
@@ -1,0 +1,40 @@
+package akka.statsd.transport
+
+import java.net.InetSocketAddress
+import akka.actor._
+import akka.io.{IO, Udp}
+import akka.util.ByteString
+
+private[statsd] class UdpUnconnected(remoteAddress: InetSocketAddress) extends Actor
+  with Stash
+  with ActorLogging {
+
+  import context.system
+
+  override def preStart(): Unit =
+    IO(Udp) ! Udp.SimpleSender
+
+  def receive: Receive = waitingForConnection
+
+  def waitingForConnection: Receive = {
+    case Udp.SimpleSenderReady ⇒
+      unstashAll()
+      context become operational(sender())
+    case _: String =>
+      stash()
+
+  }
+
+  def operational(connection: ActorRef): Receive = {
+    case msg: String =>
+      connection ! Udp.Send(ByteString(msg), remoteAddress)
+  }
+
+  override def unhandled(message: Any): Unit = {
+    log.warning(s"Unhandled message: $message (${message.getClass})")
+  }
+}
+
+private[statsd] object UdpUnconnected {
+  def props(remoteAddress: InetSocketAddress): Props = Props(new UdpUnconnected(remoteAddress))
+}

--- a/akka-statsd-core/src/test/scala/transport/UdpUnconnectedSpec.scala
+++ b/akka-statsd-core/src/test/scala/transport/UdpUnconnectedSpec.scala
@@ -1,0 +1,35 @@
+package akka.statsd.transport
+
+import akka.actor._
+import akka.io._
+import akka.statsd.{TestKit, UdpListener}
+import akka.testkit.ImplicitSender
+import java.net.InetSocketAddress
+import org.scalatest.fixture.FunSpecLike
+
+class UdpUnconnectedSpec
+  extends TestKit("udp-unconnected-spec")
+  with FunSpecLike
+  with ImplicitSender {
+
+  type FixtureParam = ActorRef
+
+  override def withFixture(test: OneArgTest) = {
+    val listener = system.actorOf(UdpListener.props(testActor), "other-end")
+    val boundListenerAddress = expectMsgClass(classOf[InetSocketAddress])
+
+    try
+      test(system.actorOf(UdpUnconnected.props(boundListenerAddress)))
+    finally
+      listener ! Udp.Unbind
+
+  }
+
+  describe("Connection") {
+    it("relays plain string messages") { connection =>
+      connection ! "msg"
+      expectMsg("msg")
+    }
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -76,8 +76,8 @@ val `akka-statsd` =
 
 def akka(lib: String) = {
   val version = lib match {
-    case x if x.startsWith("http") => "10.1.3"
-    case _ => "2.5.13"
+    case x if x.startsWith("http") => "10.1.5"
+    case _ => "2.5.18"
   }
 
   "com.typesafe.akka" %% s"akka-$lib" % version

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.2.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += "TNM" at "http://nexus.thenewmotion.com/content/groups/public"
 
-addSbtPlugin("com.newmotion" % "sbt-build-seed" % "4.0.9")
+addSbtPlugin("com.newmotion" % "sbt-build-seed" % "4.1.2")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.8-SNAPSHOT"
+version in ThisBuild := "3.1.0-SNAPSHOT"


### PR DESCRIPTION
Added a `connected-udp` flag to the config, which can be set to false in order to use an Unconnected UDP connection